### PR TITLE
Changing clientLibs concatenation to put the semicolon on its own line.

### DIFF
--- a/tasks/tasks/libs.js
+++ b/tasks/tasks/libs.js
@@ -11,7 +11,7 @@ module.exports = function (config) {
 	var insert = require('gulp-insert');
 
 	var clientLibs = _.reduce(config.clientLibs, function(r, clientLibPath){
-		r += ';' + fs.readFileSync(clientLibPath, 'utf8');
+		r += '\n;\n' + fs.readFileSync(clientLibPath, 'utf8');
 		return r;
 	}, '');
 


### PR DESCRIPTION
Was running in to an issue where files that had source mapping (or probably any line comment) at the bottom, followed by a file starting with a block comment, would cause an uglify parse error due to the start of the block comment being swallowed up by the preceding line comment.