### PR TITLE
Exit with error code when errors are caught.

### DIFF
--- a/lib/vitreum
+++ b/lib/vitreum
@@ -26,7 +26,7 @@ cli.command('* [targets...]', 'Build your project', (yargs)=>{
 			// console.log('---------------------');
 			console.log(err)
 			console.log('THERE ARE ERRORS');
-			process.exit(0);
+			process.exit(1);
 		})
 });
 


### PR DESCRIPTION
If errors occur during build, vitreum exits with a success code of `0`, which doesn't tell NPM that anything went wrong.

If we change to exit with an error code of `1`, it helps to make it a little more clear that something went wrong by giving us the classic NPM error output at the end:
```
THERE ARE ERRORS
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! chrome-mappedin@0.1.0 build: `vitreum --static`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the chrome-mappedin@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jaredtyler/.npm/_logs/2019-05-10T19_07_02_845Z-debug.log
```